### PR TITLE
fix cmake presets naming chaos

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
             "name": "common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
-            "generator": "Ninja Multi-Config"
+            "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build",
             "installDir": "${sourceDir}/out/stage"
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,16 +7,17 @@
     },
     "configurePresets": [
         {
-            "name": "config-common",
+            "name": "common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
+            "binaryDir": "${sourceDir}/build",
             "generator": "Ninja Multi-Config"
         },
         {
-            "name": "config-windows-common",
+            "name": "windows-common",
             "description": "Windows settings for MSBuild toolchain that apply to msvc and clang",
             "hidden": true,
-            "inherits": "config-common",
+            "inherits": "common",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -36,10 +37,10 @@
             }
         },
         {
-            "name": "config-unixlike-common",
+            "name": "unixlike-common",
             "description": "Unix-like OS settings for gcc and clang toolchains",
             "hidden": true,
-            "inherits": "config-common",
+            "inherits": "common",
             "condition": {
                 "type": "inList",
                 "string": "${hostSystemName}",
@@ -55,7 +56,7 @@
             }
         },
         {
-            "name": "config-msvc-compiler",
+            "name": "msvc-compiler",
             "description": "Set cl as the compiler to be used",
             "hidden": true,
             "cacheVariables": {
@@ -64,7 +65,7 @@
             }
         },
         {
-            "name": "config-clangcl-compiler",
+            "name": "clangcl-compiler",
             "description": "Set clang-cl as the compiler to be used",
             "hidden": true,
             "cacheVariables": {
@@ -78,7 +79,7 @@
             }
         },
         {
-            "name": "config-gcc-compiler",
+            "name": "gcc-compiler",
             "description": "Set gcc as the compiler to be used",
             "hidden": true,
             "cacheVariables": {
@@ -87,7 +88,7 @@
             }
         },
         {
-            "name": "config-clang-compiler",
+            "name": "clang-compiler",
             "description": "Set clang as the compiler to be used",
             "hidden": true,
             "cacheVariables": {
@@ -100,8 +101,8 @@
             "displayName": "msvc",
             "description": "Target Windows with the msvc compiler",
             "inherits": [
-                "config-windows-common",
-                "config-msvc-compiler"
+                "windows-common",
+                "msvc-compiler"
             ]
         },
         {
@@ -109,8 +110,8 @@
             "displayName": "clang",
             "description": "Target Windows with the clang compiler",
             "inherits": [
-                "config-windows-common",
-                "config-clangcl-compiler"
+                "windows-common",
+                "clangcl-compiler"
             ]
         },
         {
@@ -118,8 +119,8 @@
             "displayName": "gcc",
             "description": "Target Unix-like OS with the gcc compiler",
             "inherits": [
-                "config-unixlike-common",
-                "config-gcc-compiler"
+                "unixlike-common",
+                "gcc-compiler"
             ]
         },
         {
@@ -127,76 +128,76 @@
             "displayName": "clang",
             "description": "Target Unix-like OS with the clang compiler",
             "inherits": [
-                "config-unixlike-common",
-                "config-clang-compiler"
+                "unixlike-common",
+                "clang-compiler"
             ]
         }
     ],
     "buildPresets": [
         {
-            "name": "build-common-debug",
+            "name": "common-debug",
             "description": "Set build type to Debug",
             "hidden": true,
             "configuration": "Debug"
         },
         {
-            "name": "build-common-release",
+            "name": "common-release",
             "description": "Set build type to Release",
             "hidden": true,
             "configuration": "Release"
         },
         {
-            "name": "build-common-relwithdebinfo",
+            "name": "common-relwithdebinfo",
             "description": "Set build type to Release",
             "hidden": true,
             "configuration": "RelWithDebInfo"
         },
         {
-            "name": "build-windows-msvc-debug",
+            "name": "windows-msvc-debug",
             "displayName": "Debug",
             "description": "Build msvc debug on windows",
-            "inherits": "build-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-msvc"
         },
         {
-            "name": "build-windows-msvc-release",
+            "name": "windows-msvc-release",
             "displayName": "Release",
             "description": "Build msvc release on windows",
-            "inherits": "build-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-msvc"
         },
         {
-            "name": "build-linux-gcc-debug",
+            "name": "gcc-debug",
             "displayName": "Debug",
             "description": "Build gcc debug on linux",
-            "inherits": "build-common-debug",
-            "configurePreset": "linux-gcc"
+            "inherits": "common-debug",
+            "configurePreset": "unixlike-gcc"
         },
         {
-            "name": "build-linux-gcc-release",
+            "name": "gcc-release",
             "displayName": "Release",
             "description": "Build gcc release on linux",
-            "inherits": "build-common-release",
-            "configurePreset": "linux-gcc"
+            "inherits": "common-release",
+            "configurePreset": "unixlike-gcc"
         },
         {
-            "name": "build-linux-clang-debug",
+            "name": "clang-debug",
             "displayName": "Debug",
             "description": "Build clang debug on linux",
-            "inherits": "build-common-debug",
-            "configurePreset": "linux-clang"
+            "inherits": "common-debug",
+            "configurePreset": "unixlike-clang"
         },
         {
-            "name": "build-linux-clang-release",
+            "name": "clang-release",
             "displayName": "Release",
             "description": "Build clang release on linux",
-            "inherits": "build-common-release",
-            "configurePreset": "linux-clang"
+            "inherits": "common-release",
+            "configurePreset": "unixlike-clang"
         }
     ],
     "testPresets": [
         {
-            "name": "test-common",
+            "name": "common",
             "description": "Test CMake settings that apply to all configurations",
             "hidden": true,
             "output": {
@@ -208,73 +209,73 @@
             }
         },
         {
-            "name": "test-common-debug",
+            "name": "common-debug",
             "description": "Test CMake settings that apply to debug configurations",
             "hidden": true,
-            "inherits": "test-common",
+            "inherits": "common",
             "configuration": "Debug"
         },
         {
-            "name": "test-common-release",
+            "name": "common-release",
             "description": "Test CMake settings that apply to release configurations",
             "hidden": true,
-            "inherits": "test-common",
+            "inherits": "common",
             "configuration": "Release"
         },
         {
-            "name": "test-windows-msvc-debug",
+            "name": "windows-msvc-debug",
             "displayName": "Debug",
             "description": "Set Strict rules for windows msvc debug tests",
-            "inherits": "test-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-msvc"
         },
         {
-            "name": "test-windows-msvc-release",
+            "name": "windows-msvc-release",
             "displayName": "Release",
             "description": "Set Strict rules for windows msvc release tests",
-            "inherits": "test-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-msvc"
         },
         {
-            "name": "test-windows-clang-debug",
+            "name": "windows-clang-debug",
             "displayName": "Debug",
             "description": "Set Strict rules for windows clang debug tests",
-            "inherits": "test-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-clang"
         },
         {
-            "name": "test-windows-clang-release",
+            "name": "windows-clang-release",
             "displayName": "Release",
             "description": "Set Strict rules for windows clang release tests",
-            "inherits": "test-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-clang"
         },
         {
-            "name": "test-unixlike-gcc-debug",
+            "name": "gcc-debug",
             "displayName": "Debug",
             "description": "Set Strict rules for unixlike gcc debug tests",
-            "inherits": "test-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "unixlike-gcc"
         },
         {
-            "name": "test-unixlike-gcc-release",
+            "name": "gcc-release",
             "displayName": "Release",
             "description": "Set Strict rules for unixlike gcc release tests",
-            "inherits": "test-common-release",
+            "inherits": "common-release",
             "configurePreset": "unixlike-gcc"
         },
         {
-            "name": "test-unixlike-clang-debug",
+            "name": "clang-debug",
             "displayName": "Debug",
             "description": "Set Strict rules for unixlike clang debug tests",
-            "inherits": "test-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "unixlike-clang"
         },
         {
-            "name": "test-unixlike-clang-release",
+            "name": "clang-release",
             "displayName": "Release",
             "description": "Set Strict rules for unixlike clang release tests",
-            "inherits": "test-common-release",
+            "inherits": "common-release",
             "configurePreset": "unixlike-clang"
         }
     ]

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -7,7 +7,7 @@
     },
     "configurePresets": [
         {
-            "name": "config-developer-mode",
+            "name": "developer-mode",
             "description": "Set the flags to enable the development mode",
             "hidden": true,
             "cacheVariables": {
@@ -15,7 +15,7 @@
             }
         },
         {
-            "name": "config-user-mode",
+            "name": "user-mode",
             "description": "Set the flags to enable the user mode",
             "hidden": true,
             "cacheVariables": {
@@ -27,9 +27,9 @@
             "displayName": "msvc (Developer Mode)",
             "description": "Target Windows with the msvc compiler using Developer Mode",
             "inherits": [
-                "config-windows-common",
-                "config-msvc-compiler",
-                "config-developer-mode"
+                "windows-common",
+                "msvc-compiler",
+                "developer-mode"
             ]
         },
         {
@@ -37,69 +37,69 @@
             "displayName": "msvc (User Mode)",
             "description": "Target Windows with the msvc compiler using User Mode",
             "inherits": [
-                "config-windows-common",
-                "config-msvc-compiler",
-                "config-user-mode"
+                "windows-common",
+                "msvc-compiler",
+                "user-mode"
             ]
         }
     ],
     "buildPresets": [
         {
-            "name": "build-windows-msvc-developer-debug",
+            "name": "windows-msvc-developer-debug",
             "displayName": "Debug",
             "description": "Build msvc debug on windows (Developer Mode)",
-            "inherits": "build-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-msvc-developer"
         },
         {
-            "name": "build-windows-msvc-developer-release",
+            "name": "windows-msvc-developer-release",
             "displayName": "Release",
             "description": "Build msvc release on windows (Developer Mode)",
-            "inherits": "build-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-msvc-developer"
         },
         {
-            "name": "build-windows-msvc-user-debug",
+            "name": "windows-msvc-user-debug",
             "displayName": "Debug",
             "description": "Build msvc debug on windows (User Mode)",
-            "inherits": "build-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-msvc-user"
         },
         {
-            "name": "build-windows-msvc-user-release",
+            "name": "windows-msvc-user-release",
             "displayName": "Release",
             "description": "Build msvc release on windows (User Mode)",
-            "inherits": "build-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-msvc-user"
         }
     ],
     "testPresets": [
         {
-            "name": "test-windows-msvc-developer-debug",
+            "name": "windows-msvc-developer-debug",
             "displayName": "Debug",
             "description": "Set Strict rules for windows msvc (Developer Mode) debug tests",
-            "inherits": "test-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-msvc-developer"
         },
         {
-            "name": "test-windows-msvc-developer-release",
+            "name": "windows-msvc-developer-release",
             "displayName": "Release",
             "description": "Set Strict rules for windows msvc (Developer Mode) release tests",
-            "inherits": "test-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-msvc-developer"
         },
         {
-            "name": "test-windows-msvc-user-debug",
+            "name": "windows-msvc-user-debug",
             "displayName": "Debug",
             "description": "Set Strict rules for windows msvc (User Mode) debug tests",
-            "inherits": "test-common-debug",
+            "inherits": "common-debug",
             "configurePreset": "windows-msvc-user"
         },
         {
-            "name": "test-windows-msvc-user-release",
+            "name": "windows-msvc-user-release",
             "displayName": "Release",
             "description": "Set Strict rules for windows msvc (User Mode) release tests",
-            "inherits": "test-common-release",
+            "inherits": "common-release",
             "configurePreset": "windows-msvc-user"
         }
     ]

--- a/schemaCMakePrests.json
+++ b/schemaCMakePrests.json
@@ -1,0 +1,1313 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "The presets specify the generator and the build directory, and optionally a list of variables and other arguments to pass to CMake.",
+  "oneOf": [
+    {
+      "properties": {
+        "version": {
+          "const": 1,
+          "description": "A required integer representing the version of the JSON schema."
+        },
+        "cmakeMinimumRequired": { "$ref": "#/definitions/cmakeMinimumRequired"},
+        "vendor": { "$ref": "#/definitions/vendor" },
+        "configurePresets": { "$ref": "#/definitions/configurePresetsV1"}
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "version": {
+          "const": 2,
+          "description": "A required integer representing the version of the JSON schema."
+        },
+        "cmakeMinimumRequired": { "$ref": "#/definitions/cmakeMinimumRequired"},
+        "vendor": { "$ref": "#/definitions/vendor" },
+        "configurePresets": { "$ref": "#/definitions/configurePresetsV1"},
+        "buildPresets": { "$ref": "#/definitions/buildPresetsV2"},
+        "testPresets": { "$ref": "#/definitions/testPresetsV2"}
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "version": {
+          "const": 3,
+          "description": "A required integer representing the version of the JSON schema."
+        },
+        "cmakeMinimumRequired": { "$ref": "#/definitions/cmakeMinimumRequired"},
+        "vendor": { "$ref": "#/definitions/vendor" },
+        "configurePresets": { "$ref": "#/definitions/configurePresetsV3"},
+        "buildPresets": { "$ref": "#/definitions/buildPresetsV3"},
+        "testPresets": { "$ref": "#/definitions/testPresetsV3"}
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "version": {
+          "const": 4,
+          "description": "A required integer representing the version of the JSON schema."
+        },
+        "cmakeMinimumRequired": { "$ref": "#/definitions/cmakeMinimumRequired"},
+        "vendor": { "$ref": "#/definitions/vendor" },
+        "configurePresets": { "$ref": "#/definitions/configurePresetsV3"},
+        "buildPresets": { "$ref": "#/definitions/buildPresetsV4"},
+        "testPresets": { "$ref": "#/definitions/testPresetsV3"},
+        "include": { "$ref": "#/definitions/include"}
+      },
+      "additionalProperties": false
+    }
+  ],
+  "required": [
+    "version"
+  ],
+  "definitions": {
+    "cmakeMinimumRequired": {
+      "type": "object",
+      "description": "An optional object representing the minimum version of CMake needed to build this project.",
+      "properties": {
+        "major": {
+          "type": "integer",
+          "description": "An optional integer representing the major version."
+        },
+        "minor": {
+          "type": "integer",
+          "description": "An optional integer representing the minor version."
+        },
+        "patch": {
+          "type": "integer",
+          "description": "An optional integer representing the patch version."
+        }
+      },
+      "additionalProperties": false
+    },
+    "vendor": {
+      "type": "object",
+      "description": "An optional map containing vendor-specific information. CMake does not interpret the contents of this field except to verify that it is a map if it does exist. However, the keys should be a vendor-specific domain name followed by a /-separated path. For example, the Example IDE 1.0 could use example.com/ExampleIDE/1.0. The value of each field can be anything desired by the vendor, though will typically be a map.",
+      "properties": {}
+    },
+    "configurePresetsItemsV3": {
+      "type": "array",
+      "description": "A configure preset object.",
+      "items": {
+        "type": "object",
+        "description": "A configure preset object.",
+        "properties": {
+          "binaryDir": {
+            "type": "string",
+            "description": "An optional string representing the path to the output binary directory. This field supports macro expansion. If a relative path is specified, it is calculated relative to the source directory. If binaryDir is not specified, the path is calculated using regular methods."
+          },
+          "generator": {
+            "type": "string",
+            "description": "An optional string representing the generator to use for the preset. If generator is not specified, the normal generator discovery procedure is used. Note that for Visual Studio generators, unlike in the command line -G argument, you cannot include the platform name in the generator name. Use the architecture field instead."
+          },
+          "toolchainFile": {
+            "type": "string",
+            "description": "An optional string representing the path to the toolchain file. This field supports macro expansion. If a relative path is specified, it is calculated relative to the build directory, and if not found, relative to the source directory."
+          },
+          "installDir": {
+            "type": "string",
+            "description": "An optional string representing the path to the installation directory. This field supports macro expansion. If a relative path is specified, it is calculated relative to the source directory."
+          },
+          "condition": { "$ref": "#/definitions/topCondition" }
+        }
+      }
+    },
+    "configurePresetsItemsV1": {
+      "type": "array",
+      "description": "An optional array of configure preset objects.",
+      "items": {
+        "type": "object",
+        "description": "A configure preset object.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A required string representing the machine-friendly name of the preset. This identifier is used in the --preset argument. There must not be two presets in the union of CMakePresets.json and CMakeUserPresets.json in the same directory with the same name.",
+            "minLength": 1
+          },
+          "hidden": {
+            "type": "boolean",
+            "description": "An optional boolean specifying whether or not a preset should be hidden. If a preset is hidden, it cannot be used in the --preset= argument, will not show up in the CMake GUI, and does not have to have a valid generator or binaryDir, even from inheritance. Hidden presets are intended to be used as a base for other presets to inherit via the inherits field."
+          },
+          "inherits": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "An optional string representing the name of the preset to inherit from.",
+                "minLength": 1
+              },
+              {
+                "type": "array",
+                "description": "An optional array of strings representing the names of presets to inherit from. The preset will inherit all of the fields from the inherits presets by default (except name, hidden, inherits, description, and displayName), but can override them as desired. If multiple inherits presets provide conflicting values for the same field, the earlier preset in the inherits list will be preferred. Presets in CMakePresets.json must not inherit from presets in CMakeUserPresets.json.",
+                "items": {
+                  "type": "string",
+                  "description": "An optional string representing the name of the preset to inherit from.",
+                  "minLength": 1
+                }
+              }
+            ]
+          },
+          "vendor": {
+            "type": "object",
+            "description": "An optional map containing vendor-specific information. CMake does not interpret the contents of this field except to verify that it is a map if it does exist. However, it should follow the same conventions as the root-level vendor field. If vendors use their own per-preset vendor field, they should implement inheritance in a sensible manner when appropriate.",
+            "properties": {}
+          },
+          "displayName": {
+            "type": "string",
+            "description": "An optional string with a human-friendly name of the preset."
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional string with a human-friendly description of the preset."
+          },
+          "generator": {
+            "type": "string",
+            "description": "An optional string representing the generator to use for the preset. If generator is not specified, it must be inherited from the inherits preset (unless this preset is hidden). Note that for Visual Studio generators, unlike in the command line -G argument, you cannot include the platform name in the generator name. Use the architecture field instead."
+          },
+          "architecture": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "An optional string representing the platform for generators that support it."
+              },
+              {
+                "type": "object",
+                "description": "An optional object representing the platform for generators that support it.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "An optional string representing the value."
+                  },
+                  "strategy": {
+                    "type": "string",
+                    "description": "An optional string telling CMake how to handle the field. Valid values are: \"set\" Set the respective value. This will result in an error for generators that do not support the respective field. \"external\" Do not set the value, even if the generator supports it. This is useful if, for example, a preset uses the Ninja generator, and an IDE knows how to set up the Visual C++ environment from the architecture and toolset fields. In that case, CMake will ignore the field, but the IDE can use them to set up the environment before invoking CMake.",
+                    "enum": [
+                      "set",
+                      "external"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "toolset": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "An optional string representing the toolset for generators that support it."
+              },
+              {
+                "type": "object",
+                "description": "An optional object representing the toolset for generators that support it.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "An optional string representing the value."
+                  },
+                  "strategy": {
+                    "type": "string",
+                    "description": "An optional string telling CMake how to handle the field. Valid values are: \"set\" Set the respective value. This will result in an error for generators that do not support the respective field. \"external\" Do not set the value, even if the generator supports it. This is useful if, for example, a preset uses the Ninja generator, and an IDE knows how to set up the Visual C++ environment from the architecture and toolset fields. In that case, CMake will ignore the field, but the IDE can use them to set up the environment before invoking CMake.",
+                    "enum": [
+                      "set",
+                      "external"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "binaryDir": {
+            "type": "string",
+            "description": "An optional string representing the path to the output binary directory. This field supports macro expansion. If a relative path is specified, it is calculated relative to the source directory. If binaryDir is not specified, it must be inherited from the inherits preset (unless this preset is hidden)."
+          },
+          "cmakeExecutable": {
+            "type": "string",
+            "description": "An optional string representing the path to the CMake executable to use for this preset. This is reserved for use by IDEs, and is not used by CMake itself. IDEs that use this field should expand any macros in it."
+          },
+          "cacheVariables": {
+            "type": "object",
+            "description": "An optional map of cache variables. The key is the variable name (which must not be an empty string). Cache variables are inherited through the inherits field, and the preset's variables will be the union of its own cacheVariables and the cacheVariables from all its parents. If multiple presets in this union define the same variable, the standard rules of inherits are applied.",
+            "properties": {},
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "null",
+                  "description": "Setting a variable to null causes it to not be set, even if a value was inherited from another preset."
+                },
+                {
+                  "type": "boolean",
+                  "description": "A boolean representing the value of the variable. Equivalent to \"TRUE\" or \"FALSE\"."
+                },
+                {
+                  "type": "string",
+                  "description": "A string representing the value of the variable (which supports macro expansion)."
+                },
+                {
+                  "type": "object",
+                  "description": "An object representing the type and value of the variable.",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "An optional string representing the type of the variable. It should be BOOL, FILEPATH, PATH, STRING, or INTERNAL."
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "A required boolean representing the value of the variable. Equivalent to \"TRUE\" or \"FALSE\"."
+                        },
+                        {
+                          "type": "string",
+                          "description": "A required string representing the value of the variable. This field supports macro expansion."
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "propertyNames": {
+              "pattern": "^.+$"
+            }
+          },
+          "environment": {
+            "type": "object",
+            "description": "An optional map of environment variables. The key is the variable name (which must not be an empty string). Each variable is set regardless of whether or not a value was given to it by the process's environment. This field supports macro expansion, and environment variables in this map may reference each other, and may be listed in any order, as long as such references do not cause a cycle (for example,if ENV_1 is $env{ENV_2}, ENV_2 may not be $env{ENV_1}.) Environment variables are inherited through the inherits field, and the preset's environment will be the union of its own environment and the environment from all its parents. If multiple presets in this union define the same variable, the standard rules of inherits are applied. Setting a variable to null causes it to not be set, even if a value was inherited from another preset.",
+            "properties": {},
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "null",
+                  "description": "Setting a variable to null causes it to not be set, even if a value was inherited from another preset."
+                },
+                {
+                  "type": "string",
+                  "description": "A string representing the value of the variable."
+                }
+              ]
+            },
+            "propertyNames": {
+              "pattern": "^.+$"
+            }
+          },
+          "warnings": {
+            "type": "object",
+            "description": "An optional object specifying warnings.",
+            "properties": {
+              "dev": {
+                "type": "boolean",
+                "description": "An optional boolean. Equivalent to passing -Wdev or -Wno-dev on the command line. This may not be set to false if errors.dev is set to true."
+              },
+              "deprecated": {
+                "type": "boolean",
+                "description": "An optional boolean. Equivalent to passing -Wdeprecated or -Wno-deprecated on the command line. This may not be set to false if errors.deprecated is set to true."
+              },
+              "uninitialized": {
+                "type": "boolean",
+                "description": "An optional boolean. Setting this to true is equivalent to passing --warn-uninitialized on the command line."
+              },
+              "unusedCli": {
+                "type": "boolean",
+                "description": "An optional boolean. Setting this to false is equivalent to passing --no-warn-unused-cli on the command line."
+              },
+              "systemVars": {
+                "type": "boolean",
+                "description": "An optional boolean. Setting this to true is equivalent to passing --check-system-vars on the command line."
+              }
+            },
+            "additionalProperties": false
+          },
+          "errors": {
+            "type": "object",
+            "description": "An optional object specifying errors.",
+            "properties": {
+              "dev": {
+                "type": "boolean",
+                "description": "An optional boolean. Equivalent to passing -Werror=dev or -Wno-error=dev on the command line. This may not be set to true if warnings.dev is set to false."
+              },
+              "deprecated": {
+                "type": "boolean",
+                "description": "An optional boolean. Equivalent to passing -Werror=deprecated or -Wno-error=deprecated on the command line. This may not be set to true if warnings.deprecated is set to false."
+              }
+            },
+            "additionalProperties": false
+          },
+          "debug": {
+            "type": "object",
+            "description": "An optional object specifying debug options.",
+            "properties": {
+              "output": {
+                "type": "boolean",
+                "description": "An optional boolean. Setting this to true is equivalent to passing --debug-output on the command line."
+              },
+              "tryCompile": {
+                "type": "boolean",
+                "description": "An optional boolean. Setting this to true is equivalent to passing --debug-trycompile on the command line."
+              },
+              "find": {
+                "type": "boolean",
+                "description": "An optional boolean. Setting this to true is equivalent to passing --debug-find on the command line."
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    "configurePresetsV3": {
+      "type": "array",
+      "description": "An optional array of configure preset objects.",
+      "allOf": [
+        { "$ref": "#/definitions/configurePresetsItemsV1" },
+        { "$ref": "#/definitions/configurePresetsItemsV3" }
+      ],
+      "items": {
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "generator": {},
+          "architecture": {},
+          "toolset": {},
+          "toolchainFile": {},
+          "binaryDir": {},
+          "installDir": {},
+          "cmakeExecutable": {},
+          "cacheVariables": {},
+          "environment": {},
+          "warnings": {},
+          "errors": {},
+          "debug": {},
+          "condition": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "configurePresetsV1": {
+      "type": "array",
+      "description": "An optional array of configure preset objects.",
+      "allOf": [
+        { "$ref": "#/definitions/configurePresetsItemsV1" }
+      ],
+      "items": {
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "generator": {},
+          "architecture": {},
+          "toolset": {},
+          "binaryDir": {},
+          "cmakeExecutable": {},
+          "cacheVariables": {},
+          "environment": {},
+          "warnings": {},
+          "errors": {},
+          "debug": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "buildPresetsItemsV4": {
+      "type": "array",
+      "description": "An optional array of build preset objects. Used to specify arguments to cmake --build. Available in version 4 and higher.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "resolvePackageReferences": {
+            "type": "string",
+            "description": "An optional string specifying the package resolve behavior. Valid values are \"on\" (packages are resolved prior to the build), \"off\" (packages are not resolved prior to the build), and \"only\" (packages are resolved, but no build will be performed).",
+            "enum": [
+              "on", "off", "only"
+            ]
+          }
+        }
+      }
+    },
+    "buildPresetsItemsV3": {
+      "type": "array",
+      "description": "An optional array of build preset objects. Used to specify arguments to cmake --build. Available in version 3 and higher.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "condition": { "$ref": "#/definitions/topCondition" }
+        }
+      }
+    },
+    "buildPresetsItemsV2": {
+      "type": "array",
+      "description": "An optional array of build preset objects. Used to specify arguments to cmake --build. Available in version 2 and higher.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A required string representing the machine-friendly name of the preset. This identifier is used in the --preset argument. There must not be two presets (configure, build, or test) in the union of CMakePresets.json and CMakeUserPresets.json in the same directory with the same name.",
+            "minLength": 1
+          },
+          "hidden": {
+            "type": "boolean",
+            "description": "An optional boolean specifying whether or not a preset should be hidden. If a preset is hidden, it cannot be used in the --preset argument, will not show up in the CMake GUI, and does not have to have a valid configurePreset, even from inheritance. Hidden presets are intended to be used as a base for other presets to inherit via the inherits field."
+          },
+          "inherits": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "An optional string representing the name of the build preset to inherit from.",
+                "minLength": 1
+              },
+              {
+                "type": "array",
+                "description": "An optional array of strings representing the names of build presets to inherit from. The preset will inherit all of the fields from the inherits presets by default (except name, hidden, inherits, description, and displayName), but can override them as desired. If multiple inherits presets provide conflicting values for the same field, the earlier preset in the inherits list will be preferred. Presets in CMakePresets.json must not inherit from presets in CMakeUserPresets.json.",
+                "items": {
+                  "type": "string",
+                  "description": "An optional string representing the name of the preset to inherit from.",
+                  "minLength": 1
+                }
+              }
+            ]
+          },
+          "configurePreset": {
+            "type": "string",
+            "description": "An optional string specifying the name of a configure preset to associate with this build preset. If configurePreset is not specified, it must be inherited from the inherits preset (unless this preset is hidden). The build tree directory is inferred from the configure preset.",
+            "minLength": 1
+          },
+          "vendor": {
+            "type": "object",
+            "description": "An optional map containing vendor-specific information. CMake does not interpret the contents of this field except to verify that it is a map if it does exist. However, it should follow the same conventions as the root-level vendor field. If vendors use their own per-preset vendor field, they should implement inheritance in a sensible manner when appropriate.",
+            "properties": {}
+          },
+          "displayName": {
+            "type": "string",
+            "description": "An optional string with a human-friendly name of the preset."
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional string with a human-friendly description of the preset."
+          },
+          "inheritConfigureEnvironment": {
+            "type": "boolean",
+            "description": "An optional boolean that defaults to true. If true, the environment variables from the associated configure preset are inherited after all inherited build preset environments, but before environment variables explicitly specified in this build preset."
+          },
+          "environment": {
+            "type": "object",
+            "description": "An optional map of environment variables. The key is the variable name (which must not be an empty string). Each variable is set regardless of whether or not a value was given to it by the process's environment. This field supports macro expansion, and environment variables in this map may reference each other, and may be listed in any order, as long as such references do not cause a cycle (for example,if ENV_1 is $env{ENV_2}, ENV_2 may not be $env{ENV_1}.) Environment variables are inherited through the inherits field, and the preset's environment will be the union of its own environment and the environment from all its parents. If multiple presets in this union define the same variable, the standard rules of inherits are applied. Setting a variable to null causes it to not be set, even if a value was inherited from another preset.",
+            "properties": {},
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "null",
+                  "description": "Setting a variable to null causes it to not be set, even if a value was inherited from another preset."
+                },
+                {
+                  "type": "string",
+                  "description": "A string representing the value of the variable."
+                }
+              ]
+            },
+            "propertyNames": {
+              "pattern": "^.+$"
+            }
+          },
+          "jobs": {
+            "type": "integer",
+            "description": "An optional integer. Equivalent to passing --parallel or -j on the command line."
+          },
+          "targets": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "An optional string. Equivalent to passing --target or -t on the command line. Vendors may ignore the targets property or hide build presets that explicitly specify targets."
+              },
+              {
+                "type": "array",
+                "description": "An optional array of strings. Equivalent to passing --target or -t on the command line. Vendors may ignore the targets property or hide build presets that explicitly specify targets.",
+                "items": {
+                  "type": "string",
+                  "description": "An optional string. Equivalent to passing --target or -t on the command line. Vendors may ignore the targets property or hide build presets that explicitly specify targets."
+                }
+              }
+            ]
+          },
+          "configuration": {
+            "type": "string",
+            "description": "An optional string. Equivalent to passing --config on the command line."
+          },
+          "cleanFirst": {
+            "type": "boolean",
+            "description": "An optional boolean. If true, equivalent to passing --clean-first on the command line."
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "An optional boolean. If true, equivalent to passing --verbose on the command line."
+          },
+          "nativeToolOptions": {
+            "type": "array",
+            "description": "An optional array of strings. Equivalent to passing options after -- on the command line.",
+            "items": {
+              "type": "string",
+              "description": "An optional string representing an option to pass after -- on the command line."
+            }
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "buildPresetsV4": {
+      "type": "array",
+      "description": "An optional array of build preset objects. Used to specify arguments to cmake --build. Available in version 4 and higher.",
+      "allOf": [
+        { "$ref": "#/definitions/buildPresetsItemsV4" },
+        { "$ref": "#/definitions/buildPresetsItemsV3" },
+        { "$ref": "#/definitions/buildPresetsItemsV2" }
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "configurePreset": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "inheritConfigureEnvironment": {},
+          "environment": {},
+          "jobs": {},
+          "targets": {},
+          "configuration": {},
+          "cleanFirst": {},
+          "resolvePackageReferences": {},
+          "verbose": {},
+          "nativeToolOptions": {},
+          "condition": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "buildPresetsV3": {
+      "type": "array",
+      "description": "An optional array of build preset objects. Used to specify arguments to cmake --build. Available in version 3 and higher.",
+      "allOf": [
+        { "$ref": "#/definitions/buildPresetsItemsV3" },
+        { "$ref": "#/definitions/buildPresetsItemsV2" }
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "configurePreset": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "inheritConfigureEnvironment": {},
+          "environment": {},
+          "jobs": {},
+          "targets": {},
+          "configuration": {},
+          "cleanFirst": {},
+          "verbose": {},
+          "nativeToolOptions": {},
+          "condition": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "buildPresetsV2": {
+      "type": "array",
+      "description": "An optional array of build preset objects. Used to specify arguments to cmake --build. Available in version 2 and higher.",
+      "allOf": [
+        { "$ref": "#/definitions/buildPresetsItemsV2" }
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "configurePreset": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "inheritConfigureEnvironment": {},
+          "environment": {},
+          "jobs": {},
+          "targets": {},
+          "configuration": {},
+          "cleanFirst": {},
+          "verbose": {},
+          "nativeToolOptions": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "testPresetsItemsV3": {
+      "type": "array",
+      "description": "An optional array of test preset objects. Used to specify arguments to ctest. Available in version 3 and higher.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "condition": { "$ref": "#/definitions/topCondition" }
+        }
+      }
+    },
+    "testPresetsItemsV2": {
+      "type": "array",
+      "description": "An optional array of test preset objects. Used to specify arguments to ctest. Available in version 2 and higher.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A required string representing the machine-friendly name of the preset. This identifier is used in the --preset argument. There must not be two presets (configure, build, or test) in the union of CMakePresets.json and CMakeUserPresets.json in the same directory with the same name.",
+            "minLength": 1
+          },
+          "hidden": {
+            "type": "boolean",
+            "description": "An optional boolean specifying whether or not a preset should be hidden. If a preset is hidden, it cannot be used in the --preset argument, will not show up in the CMake GUI, and does not have to have a valid configurePreset, even from inheritance. Hidden presets are intended to be used as a base for other presets to inherit via the inherits field."
+          },
+          "inherits": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "An optional string representing the name of the test preset to inherit from.",
+                "minLength": 1
+              },
+              {
+                "type": "array",
+                "description": "An optional array of strings representing the names of test presets to inherit from. The preset will inherit all of the fields from the inherits presets by default (except name, hidden, inherits, description, and displayName), but can override them as desired. If multiple inherits presets provide conflicting values for the same field, the earlier preset in the inherits list will be preferred. Presets in CMakePresets.json must not inherit from presets in CMakeUserPresets.json.",
+                "items": {
+                  "type": "string",
+                  "description": "An optional string representing the name of the preset to inherit from.",
+                  "minLength": 1
+                }
+              }
+            ]
+          },
+          "configurePreset": {
+            "type": "string",
+            "description": "An optional string specifying the name of a configure preset to associate with this test preset. If configurePreset is not specified, it must be inherited from the inherits preset (unless this preset is hidden). The build tree directory is inferred from the configure preset.",
+            "minLength": 1
+          },
+          "vendor": {
+            "type": "object",
+            "description": "An optional map containing vendor-specific information. CMake does not interpret the contents of this field except to verify that it is a map if it does exist. However, it should follow the same conventions as the root-level vendor field. If vendors use their own per-preset vendor field, they should implement inheritance in a sensible manner when appropriate.",
+            "properties": {}
+          },
+          "displayName": {
+            "type": "string",
+            "description": "An optional string with a human-friendly name of the preset."
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional string with a human-friendly description of the preset."
+          },
+          "inheritConfigureEnvironment": {
+            "type": "boolean",
+            "description": "An optional boolean that defaults to true. If true, the environment variables from the associated configure preset are inherited after all inherited test preset environments, but before environment variables explicitly specified in this test preset."
+          },
+          "environment": {
+            "type": "object",
+            "description": "An optional map of environment variables. The key is the variable name (which must not be an empty string). Each variable is set regardless of whether or not a value was given to it by the process's environment. This field supports macro expansion, and environment variables in this map may reference each other, and may be listed in any order, as long as such references do not cause a cycle (for example,if ENV_1 is $env{ENV_2}, ENV_2 may not be $env{ENV_1}.) Environment variables are inherited through the inherits field, and the preset's environment will be the union of its own environment and the environment from all its parents. If multiple presets in this union define the same variable, the standard rules of inherits are applied. Setting a variable to null causes it to not be set, even if a value was inherited from another preset.",
+            "properties": {},
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "null",
+                  "description": "Setting a variable to null causes it to not be set, even if a value was inherited from another preset."
+                },
+                {
+                  "type": "string",
+                  "description": "A string representing the value of the variable."
+                }
+              ]
+            },
+            "propertyNames": {
+              "pattern": "^.+$"
+            }
+          },
+          "configuration": {
+            "type": "string",
+            "description": "An optional string. Equivalent to passing --build-config on the command line."
+          },
+          "overwriteConfigurationFile": {
+            "type": "array",
+            "description": "An optional array of configuration options to overwrite options specified in the CTest configuration file. Equivalent to passing ``--overwrite`` for each value in the array.",
+            "items": {
+              "type": "string",
+              "description": "An option written as a key-value pair in the form \"key=value\"."
+            }
+          },
+          "output": {
+            "type": "object",
+            "description": "An optional object specifying output options.",
+            "properties": {
+              "shortProgress": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --progress on the command line."
+              },
+              "verbosity": {
+                "type": "string",
+                "description": "An optional string specifying verbosity level. Valid values are \"default\" (equivalent to passing no verbosity flags on the command line), \"verbose\" (equivalent to passing --verbose on the command line), and \"extra\" (equivalent to passing --extra-verbose on the command line).",
+                "enum": [
+                  "default", "verbose", "extra"
+                ]
+              },
+              "debug": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --debug on the command line."
+              },
+              "outputOnFailure": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --output-on-failure on the command line."
+              },
+              "quiet": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --quiet on the command line."
+              },
+              "outputLogFile": {
+                "type": "string",
+                "description": "An optional string specifying a path to a log file. Equivalent to passing --output-log on the command line."
+              },
+              "labelSummary": {
+                "type": "boolean",
+                "description": "An optional boolean. If false, equivalent to passing --no-label-summary on the command line."
+              },
+              "subprojectSummary": {
+                "type": "boolean",
+                "description": "An optional boolean. If false, equivalent to passing --no-subproject-summary on the command line."
+              },
+              "maxPassedTestOutputSize": {
+                "type": "integer",
+                "description": "An optional integer specifying the maximum output for passed tests in bytes. Equivalent to passing --test-output-size-passed on the command line."
+              },
+              "maxFailedTestOutputSize": {
+                "type": "integer",
+                "description": "An optional integer specifying the maximum output for failed tests in bytes. Equivalent to passing --test-output-size-failed on the command line."
+              },
+              "maxTestNameWidth": {
+                "type": "integer",
+                "description": "An optional integer specifying the maximum width of a test name to output. Equivalent to passing --max-width on the command line."
+              }
+            },
+            "additionalProperties": false
+          },
+          "filter": {
+            "type": "object",
+            "description": "An optional object specifying how to filter the tests to run.",
+            "properties": {
+              "include": {
+                "type": "object",
+                "description": "An optional object specifying which tests to include.",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "An optional string specifying a regex for test names. Equivalent to passing --tests-regex on the command line."
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "An optional string specifying a regex for test labels. Equivalent to passing --label-regex on the command line."
+                  },
+                  "index": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "description": "An optional object specifying tests to include by test index.",
+                        "properties": {
+                          "start": {
+                            "type": "integer",
+                            "description": "An optional integer specifying a test index to start testing at."
+                          },
+                          "end": {
+                            "type": "integer",
+                            "description": "An optional integer specifying a test index to stop testing at."
+                          },
+                          "stride": {
+                            "type": "integer",
+                            "description": "An optional integer specifying the increment."
+                          },
+                          "specificTests": {
+                            "type": "array",
+                            "description": "An optional array of integers specifying specific test indices to run.",
+                            "items": {
+                              "type": "integer",
+                              "description": "An integer specifying the test to run by index."
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "string",
+                        "description": "An optional string specifying a file with the command line syntax for --tests-information."
+                      }
+                    ]
+                  },
+                  "useUnion": {
+                    "type": "boolean",
+                    "description": "An optional boolean. Equivalent to passing --union on the command line."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "exclude": {
+                "type": "object",
+                "description": "An optional object specifying which tests to exclude.",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "An optional string specifying a regex for test names. Equivalent to passing --exclude-regex on the command line."
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "An optional string specifying a regex for test labels. Equivalent to passing --label-exclude on the command line."
+                  },
+                  "fixtures": {
+                    "type": "object",
+                    "description": "An optional object specifying which fixtures to exclude from adding tests.",
+                    "properties": {
+                      "any": {
+                        "type": "string",
+                        "description": "An optional string specifying a regex for text fixtures to exclude from adding any tests. Equivalent to --fixture-exclude-any on the command line."
+                      },
+                      "setup": {
+                        "type": "string",
+                        "description": "An optional string specifying a regex for text fixtures to exclude from adding setup tests. Equivalent to --fixture-exclude-setup on the command line."
+                      },
+                      "cleanup": {
+                        "type": "string",
+                        "description": "An optional string specifying a regex for text fixtures to exclude from adding cleanup tests. Equivalent to --fixture-exclude-cleanup on the command line."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "execution": {
+            "type": "object",
+            "description": "An optional object specifying options for test execution.",
+            "properties": {
+              "stopOnFailure": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --stop-on-failure on the command line."
+              },
+              "enableFailover": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing -F on the command line."
+              },
+              "jobs": {
+                "type": "integer",
+                "description": "An optional integer. Equivalent to passing --parallel on the command line."
+              },
+              "resourceSpecFile": {
+                "type": "string",
+                "description": "An optional string. Equivalent to passing --resource-spec-file on the command line."
+              },
+              "testLoad": {
+                "type": "integer",
+                "description": "An optional integer. Equivalent to passing --test-load on the command line."
+              },
+              "showOnly": {
+                "type": "string",
+                "description": "An optional string. Equivalent to passing --show-only on the command line. Value must be \"human\" or \"json-v1\".",
+                "enum": [
+                  "human", "json-v1"
+                ]
+              },
+              "repeat": {
+                "type": "object",
+                "description": "An optional object specifying how to repeat tests. Equivalent to passing --repeat on the command line.",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "description": "A required string. Must be one of the following values: \"until-fail\", \"until-pass\", or \"after-timeout\".",
+                    "enum": [
+                      "until-fail", "until-pass", "after-timeout"
+                    ]
+                  },
+                  "count": {
+                    "type": "integer",
+                    "description": "A required integer."
+                  }
+                },
+                "required": [
+                  "mode", "count"
+                ],
+                "additionalProperties": false
+              },
+              "interactiveDebugging": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --interactive-debug-mode 1 on the command line. If false, equivalent to passing --interactive-debug-mode 0 on the command line."
+              },
+              "scheduleRandom": {
+                "type": "boolean",
+                "description": "An optional boolean. If true, equivalent to passing --schedule-random on the command line."
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "An optional integer. Equivalent to passing --timeout on the command line."
+              },
+              "noTestsAction": {
+                "type": "string",
+                "description": "An optional string specifying the behavior if no tests are found. Must be one of the following values: \"default\" (equivalent to not passing any value on the command line), \"error\" (equivalent to passing --no-tests=error on the command line), or \"ignore\" (equivalent to passing --no-tests-ignore on the command line).",
+                "enum": [
+                  "default", "error", "ignore"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "testPresetsV3": {
+      "type": "array",
+      "description": "An optional array of test preset objects. Used to specify arguments to ctest. Available in version 3 and higher.",
+      "allOf": [
+        { "$ref": "#/definitions/testPresetsItemsV2" },
+        { "$ref": "#/definitions/testPresetsItemsV3" }
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "configurePreset": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "inheritConfigureEnvironment": {},
+          "environment": {},
+          "configuration": {},
+          "overwriteConfigurationFile": {},
+          "output": {},
+          "filter": {},
+          "execution": {},
+          "condition": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "testPresetsV2": {
+      "type": "array",
+      "description": "An optional array of test preset objects. Used to specify arguments to ctest. Available in version 2 and higher.",
+      "allOf": [
+        { "$ref": "#/definitions/testPresetsItemsV2" }
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {},
+          "hidden": {},
+          "inherits": {},
+          "configurePreset": {},
+          "vendor": {},
+          "displayName": {},
+          "description": {},
+          "inheritConfigureEnvironment": {},
+          "environment": {},
+          "configuration": {},
+          "overwriteConfigurationFile": {},
+          "output": {},
+          "filter": {},
+          "execution": {}
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "condition": {
+      "anyOf": [
+        {
+          "type": "boolean",
+          "description": "A boolean which provides a constant value for the condition's evaluation."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "const"
+            },
+            "value": {
+              "type": "boolean",
+              "description": "A required boolean which provides a constant value for the condition's evaluation."
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "equals"
+            },
+            "lhs": {
+              "type": "string",
+              "description": "First string to compare. This field supports macro expansion."
+            },
+            "rhs": {
+              "type": "string",
+              "description": "Second string to compare. This field supports macro expansion."
+            }
+          },
+          "required": [
+            "type",
+            "lhs",
+            "rhs"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "notEquals"
+            },
+            "lhs": {
+              "type": "string",
+              "description": "First string to compare. This field supports macro expansion."
+            },
+            "rhs": {
+              "type": "string",
+              "description": "Second string to compare. This field supports macro expansion."
+            }
+          },
+          "required": [
+            "type",
+            "lhs",
+            "rhs"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "inList"
+            },
+            "string": {
+              "type": "string",
+              "description": "A required string to search for. This field supports macro expansion."
+            },
+            "list": {
+              "type": "array",
+              "description": "A required list of strings to search. This field supports macro expansion, and uses short-circuit evaluation.",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "type",
+            "string",
+            "list"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "notInList"
+            },
+            "string": {
+              "type": "string",
+              "description": "A required string to search for. This field supports macro expansion."
+            },
+            "list": {
+              "type": "array",
+              "description": "A required list of strings to search. This field supports macro expansion, and uses short-circuit evaluation.",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "type",
+            "string",
+            "list"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "matches"
+            },
+            "string": {
+              "type": "string",
+              "description": "A required string to search. This field supports macro expansion."
+            },
+            "regex": {
+              "type": "string",
+              "description": "A required regular expression to search for. This field supports macro expansion."
+            }
+          },
+          "required": [
+            "type",
+            "string",
+            "regex"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "notMatches"
+            },
+            "string": {
+              "type": "string",
+              "description": "A required string to search. This field supports macro expansion."
+            },
+            "regex": {
+              "type": "string",
+              "description": "A required regular expression to search for. This field supports macro expansion."
+            }
+          },
+          "required": [
+            "type",
+            "string",
+            "regex"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "anyOf"
+            },
+            "conditions": {
+              "type": "array",
+              "description": "A required array of condition objects. These conditions use short-circuit evaluation.",
+              "items": { "$ref": "#/definitions/condition" }
+            }
+          },
+          "required": [
+            "type",
+            "conditions"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "allOf"
+            },
+            "conditions": {
+              "type": "array",
+              "description": "A required array of condition objects. These conditions use short-circuit evaluation.",
+              "items": { "$ref": "#/definitions/condition" }
+            }
+          },
+          "required": [
+            "type",
+            "conditions"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A required string specifying the type of the condition.",
+              "const": "not"
+            },
+            "condition": { "$ref": "#/definitions/condition" }
+          },
+          "required": [
+            "type",
+            "condition"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "topCondition": {
+      "anyOf": [
+        { "$ref": "#/definitions/condition" },
+        {
+          "type": "null",
+          "description": "Null indicates that the condition always evaluates to true and is not inherited."
+        }
+      ]
+    },
+    "include": {
+      "type": "array",
+      "description": "An optional array of strings representing files to include. If the filenames are not absolute, they are considered relative to the current file.",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
preset names have it own scope.
use simple and short names were possible